### PR TITLE
Fix error popup when closing a dialog opened from a x2many widget

### DIFF
--- a/web_selenium/static/src/xml/base_ext.xml
+++ b/web_selenium/static/src/xml/base_ext.xml
@@ -195,10 +195,10 @@
 
     <!-- adapted, but not tested: 9.0 EE -->
     <t t-extend="X2ManyControlPanel">
-	    <t t-jquery="div.o_x2m_control_panel">
-            this.attr('t-att-data-bt-testing-model_name', 'widget.__parentedParent.view.model');
-            this.attr('t-att-data-bt-testing-name', 'widget.__parentedParent.dataset.child_name');
-            this.attr('t-att-data-bt-testing-submodel_name', 'widget.__parentedParent.dataset.model');
+        <t t-jquery="div.o_x2m_control_panel">
+            this.attr('t-att-data-bt-testing-model_name', 'widget.__parentedParent and widget.__parentedParent.view.model');
+            this.attr('t-att-data-bt-testing-name', 'widget.__parentedParent and widget.__parentedParent.dataset.child_name');
+            this.attr('t-att-data-bt-testing-submodel_name', 'widget.__parentedParent and widget.__parentedParent.dataset.model');
         </t>
     </t>
 


### PR DESCRIPTION
Don't know about Odoo 9, but this happens on Odoo 10 enterprise.

Get to a form with a onetomany widget. Click on add an item, or open an existing one, so a dialog pops up. Close this dialog, then an error dialog pops up, and in the console you get:

` Cannot read property 'view' of undefined`